### PR TITLE
Fix install copy on Windows.

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -12,9 +12,9 @@ import boostcpp ;
 import path ;
 import option ;
 
-local DIST_DIR = [ path.make [ option.get distdir ] ] ;
-DIST_DIR ?= [ path.join [ path.make $(BOOST_ROOT) ] dist ] ;
-DIST_DIR = [ path.root $(DIST_DIR) [ path.pwd ] ] ;
+local DIST_DIR = [ option.get distdir ] ;
+DIST_DIR ?= [ path.join $(BOOST_ROOT) dist ] ;
+DIST_DIR = [ path.root [ path.make $(DIST_DIR) ] [ path.pwd ] ] ;
 local DIST_BIN = [ path.join $(DIST_DIR) bin ] ;
 
 exe auto_index : 

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -13,7 +13,7 @@ import path ;
 import option ;
 
 local DIST_DIR = [ option.get distdir ] ;
-DIST_DIR ?= [ path.join $(BOOST_ROOT) dist ] ;
+DIST_DIR ?= [ path.join [ path.make $(BOOST_ROOT) ] dist ] ;
 DIST_DIR = [ path.root $(DIST_DIR) [ path.pwd ] ] ;
 local DIST_BIN = [ path.join $(DIST_DIR) bin ] ;
 

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -12,7 +12,7 @@ import boostcpp ;
 import path ;
 import option ;
 
-local DIST_DIR = [ option.get distdir ] ;
+local DIST_DIR = [ path.make [ option.get distdir ] ] ;
 DIST_DIR ?= [ path.join [ path.make $(BOOST_ROOT) ] dist ] ;
 DIST_DIR = [ path.root $(DIST_DIR) [ path.pwd ] ] ;
 local DIST_BIN = [ path.join $(DIST_DIR) bin ] ;


### PR DESCRIPTION
We need to normalize distdir path before rooting against current dir as that only works if both paths are normalized.
