### PR TITLE
Honor build_dir first when installing so that installation should be …

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -12,7 +12,8 @@ import boostcpp ;
 import path ;
 import option ;
 
-local DIST_DIR = [ option.get distdir ] ;
+local DIST_DIR = [ option.get build-dir ] ;
+DIST_DIR ?= [ option.get distdir ] ;
 DIST_DIR ?= [ path.join $(BOOST_ROOT) dist ] ;
 DIST_DIR = [ path.root [ path.make $(DIST_DIR) ] [ path.pwd ] ] ;
 local DIST_BIN = [ path.join $(DIST_DIR) bin ] ;


### PR DESCRIPTION
…made outside of Boost tree if user desires.