### PR TITLE
Allow tests to be run from any directory (such as Boost root)

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -10,7 +10,10 @@ import type ;
 
 alias line_compare_tool : ../../quickbook/test/src//line-compare-tool ;
 
-rule auto-index-test ( target-name : input-file : output-file ? : options * )
+path-constant ROOT : ../../.. ;
+path-constant HERE : . ;
+
+rule auto-index-test ( target-name : input-file : script-file : output-file ? : options * )
 {
     local project = [ project.current ] ;
 
@@ -21,13 +24,15 @@ rule auto-index-test ( target-name : input-file : output-file ? : options * )
             : [ alias autoindex : ../build//auto_index : release ]
             : $(requirements)
                 <location-prefix>$(target-name).test
-                <testing.arg>--prefix=../../..
+                <testing.arg>--prefix=$(ROOT)
                 <testing.arg>$(options)
-                <testing.arg>--in=$(input-file)
-                <testing.arg>--out=$(target-name).out
+                <testing.arg>--in=$(HERE)/$(input-file)
+                <testing.arg>--script=$(HERE)/$(script-file)
+                <testing.arg>--out=$(HERE)/$(target-name).out
                 <preserve-test-targets>on
                 <dependency>Jamfile.v2
                 <dependency>$(input-file)
+                <dependency>$(script-file)
         ]
         ;
     
@@ -38,13 +43,14 @@ rule auto-index-test ( target-name : input-file : output-file ? : options * )
             : .//line_compare_tool
             : $(requirements)
                 <location-prefix>$(target-name).test
-                <testing.arg>$(target-name).out
-                <testing.arg>$(target-name).gold
+                <testing.arg>$(HERE)/$(target-name).out
+                <testing.arg>$(HERE)/$(target-name).gold
                 <preserve-test-targets>on
                 <dependency>$(target_name)
                 <implicit-dependency>$(target_name)
                 <dependency>Jamfile.v2
                 <dependency>$(input-file)
+                <dependency>$(script-file)
         ]
         ;
 
@@ -53,10 +59,6 @@ rule auto-index-test ( target-name : input-file : output-file ? : options * )
     return $(t) ;
 }
 
-auto-index-test test1 : type_traits.docbook : : --script=index.idx ;
-auto-index-test test2 : type_traits.docbook : : --internal-index --script=index.idx ;
-auto-index-test test3 : type_traits.docbook : : --internal-index --index-type=index --script=index.idx ;
-
-
-
-
+auto-index-test test1 : type_traits.docbook : index.idx ;
+auto-index-test test2 : type_traits.docbook : index.idx : : --internal-index ;
+auto-index-test test3 : type_traits.docbook : index.idx : : --internal-index --index-type=index ;


### PR DESCRIPTION
`b2 tools/auto_index/test` from the Boost root fails; this makes it work. I'm not 100% certain that this is the proper fix - the output should in principle go in `bin.v2` and perhaps either a `make` or a `generate` rule should be used - but it seems to do the job.